### PR TITLE
Fix user/password typo in set-up doc.

### DIFF
--- a/dco/hiroshi_ito.dco
+++ b/dco/hiroshi_ito.dco
@@ -1,0 +1,9 @@
+1) I, Hiroshi Ito, certify that all work committed with the commit message 
+"covered by: hiroshi_ito.dco" is my original work and I own the copyright 
+to this work. I agree to contribute this code under the Apache 2.0 license.
+
+2) I understand and agree all contribution including all personal 
+information I submit with it is maintained indefinitely and may be 
+redistributed consistent with the open source license(s) involved. 
+
+This certification is effective for all code contributed from 2018-02-13 to 9999-01-01.

--- a/internal/doc/kata-setup.md
+++ b/internal/doc/kata-setup.md
@@ -170,7 +170,7 @@ $KATA_HOME/kata-files/setup/dbviewer.sh
 
 B) Use any DB viewer tool that you'd like with the following information.
 
-* User/password is deployer/deploypass
+* User/password is katadeployer/katadeploypass
 * URL is jdbc:hsqldb:hsql://localhost:9092/obevokata
 * Driver is org.hsqldb.jdbc.JDBCDriver
 * Driver jar is available at kata-files/setup/hsqldb-2.3.4.jar


### PR DESCRIPTION
`deployer/deploypass` => `katadeployer/katadeploypass`.